### PR TITLE
#26 flash current story when consensus is achieved

### DIFF
--- a/client/app/assets/poinz.styl
+++ b/client/app/assets/poinz.styl
@@ -771,8 +771,22 @@ $backlogWidth = 300px
 
     .selected-story {
       background white
-      border: 1px solid $zuehlkeLighterGrey
+      border 1px solid $zuehlkeLighterGrey
       padding 8px
+      position relative
+
+      > .applause-highlight{
+        position absolute
+        top 0
+        left 0
+        width 100%
+        height 100%
+        border 1px solid $zuehlkeLighterGrey
+        animation-name flash_shadow
+        animation-duration 2s
+        animation-timing-function linear
+        animation-iteration-count 3
+      }
 
       h4 {
         margin-top 8px
@@ -934,4 +948,29 @@ $backlogWidth = 300px
 // in every screen-size, if backlog-active class is set, show menu
 .board .backlog.backlog-active {
   left $backlogWidth
+}
+
+
+//@keyframes flash_border {
+//  0% {
+//    border-color: rgb(201, 200, 87);
+//  }
+//  50% {
+//    border-color: $zuehlkeLighterGrey;
+//  }
+//  100% {
+//    border-color: rgb(201, 200, 87);
+//  }
+//}
+
+@keyframes flash_shadow {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/client/app/components/Estimation.js
+++ b/client/app/components/Estimation.js
@@ -7,6 +7,7 @@ import {newEstimationRound, reveal} from '../actions';
 
 import Cards from './Cards';
 import ConsensusBadge from './ConsensusBadge';
+import {getCardConfigForValue} from '../services/getCardConfigForValue';
 
 /**
  * Displays
@@ -15,7 +16,7 @@ import ConsensusBadge from './ConsensusBadge';
  * - action buttons ("reveal manually" and "new round")
  *
  */
-const Estimation = ({t, selectedStory, user, cardConfig, newEstimationRound, reveal}) => {
+const Estimation = ({t, selectedStory, applause, user, cardConfig, newEstimationRound, reveal}) => {
   const ownEstimate = selectedStory.estimations[user.id];
 
   const revealed = selectedStory.revealed;
@@ -24,16 +25,25 @@ const Estimation = ({t, selectedStory, user, cardConfig, newEstimationRound, rev
 
   return (
     <div className="estimation">
-      <div className="selected-story">
+      <div
+        className={`selected-story ${selectedStory.consensus ? 'selected-story-consensus' : ''} ${
+          selectedStory.applause ? 'applause' : ''
+        }`}
+      >
         <h4>
           {selectedStory.title}
           {selectedStory.consensus && (
             <ConsensusBadge cardConfig={cardConfig} consensusValue={selectedStory.consensus} />
           )}
         </h4>
+
         <div className="story-text">
           <Anchorify text={selectedStory.description} />
         </div>
+
+        {selectedStory.consensus && applause && (
+          <ApplauseHighlight cardConfig={cardConfig} consensusValue={selectedStory.consensus} />
+        )}
       </div>
 
       {userCanCurrentlyEstimate && <Cards ownEstimate={ownEstimate} />}
@@ -71,6 +81,7 @@ Estimation.propTypes = {
   t: PropTypes.func,
   cardConfig: PropTypes.array,
   selectedStory: PropTypes.object,
+  applause: PropTypes.bool,
   user: PropTypes.object,
   newEstimationRound: PropTypes.func,
   reveal: PropTypes.func
@@ -81,7 +92,28 @@ export default connect(
     t: state.translator,
     selectedStory: state.stories[state.selectedStory],
     user: state.users[state.userId],
+    applause: state.applause,
     cardConfig: state.cardConfig
   }),
   {newEstimationRound, reveal}
 )(Estimation);
+
+const ApplauseHighlight = ({cardConfig, consensusValue}) => {
+  if (!consensusValue) {
+    return null;
+  }
+
+  const matchingCardConfig = getCardConfigForValue(cardConfig, consensusValue);
+  const highlightColor = matchingCardConfig.color;
+  return (
+    <div
+      className="applause-highlight"
+      style={{boxShadow: '0 0 10px ' + highlightColor, border: '1px solid ' + highlightColor}}
+    ></div>
+  );
+};
+
+ApplauseHighlight.propTypes = {
+  cardConfig: PropTypes.array,
+  consensusValue: PropTypes.number
+};

--- a/client/app/services/eventReducer.js
+++ b/client/app/services/eventReducer.js
@@ -254,7 +254,11 @@ const eventActionHandlers = {
    * the selected story was set (i.e. the one that can be currently estimated by the team)
    */
   [EVENT_ACTION_TYPES.storySelected]: {
-    fn: (state, payload) => ({...state, selectedStory: payload.storyId}),
+    fn: (state, payload) => ({
+      ...state,
+      selectedStory: payload.storyId,
+      applause: false
+    }),
     log: (username, payload, oldState, newState) =>
       `${username} selected current story "${newState.stories[payload.storyId].title}"`
   },
@@ -356,6 +360,7 @@ const eventActionHandlers = {
   [EVENT_ACTION_TYPES.consensusAchieved]: {
     fn: (state, payload) => ({
       ...state,
+      applause: true,
       stories: {
         ...state.stories,
         [payload.storyId]: {
@@ -415,6 +420,7 @@ const eventActionHandlers = {
   [EVENT_ACTION_TYPES.newEstimationRoundStarted]: {
     fn: (state, payload) => ({
       ...state,
+      applause: false,
       stories: {
         ...state.stories,
         [payload.storyId]: {

--- a/client/test/unit/eventActionReducersScenarios/backlogModifyingTest.js
+++ b/client/test/unit/eventActionReducersScenarios/backlogModifyingTest.js
@@ -182,6 +182,19 @@ test('Editing stories', () => {
     {
       event: {
         id: uuid(),
+        userId: ownUserId,
+        correlationId: uuid(),
+        name: 'storySelected',
+        roomId,
+        payload: {
+          storyId: secondStoryId
+        }
+      },
+      type: EVENT_ACTION_TYPES.storySelected
+    },
+    {
+      event: {
+        id: uuid(),
         userId: otherUserId,
         correlationId: uuid(),
         name: 'storyChanged',
@@ -197,7 +210,8 @@ test('Editing stories', () => {
   ];
 
   modifiedState = reduceMultipleEventActions(startingState, eventActions);
-  expect(modifiedState.selectedStory).toEqual(firstStoryId);
+  expect(modifiedState.selectedStory).toEqual(secondStoryId);
+  expect(modifiedState.applause).toEqual(false);
   expect(modifiedState.stories).toEqual({
     [secondStoryId]: {
       createdAt: 1592115972307,

--- a/client/test/unit/eventActionReducersScenarios/estimatingTest.js
+++ b/client/test/unit/eventActionReducersScenarios/estimatingTest.js
@@ -183,6 +183,8 @@ test('Estimation with two users', () => {
     id: firstStoryId,
     title: 'FirstStory'
   });
+
+  expect(modifiedState.applause).toBe(true);
 });
 
 test('New estimation round with two users', () => {
@@ -216,6 +218,7 @@ test('New estimation round with two users', () => {
         }
       },
       selectedStory: firstStoryId,
+      applause: true,
       stories: {
         [firstStoryId]: {
           createdAt: 1592115935676,
@@ -259,4 +262,6 @@ test('New estimation round with two users', () => {
       title: 'FirstStory'
     }
   });
+
+  expect(modifiedState.applause).toBe(false);
 });


### PR DESCRIPTION
- set "applause" flag on state on "consensusAchieved" event. reset flag on storySelected and on new estimation round
- use flag to display "flashing" border and shadow around current story