### PR TITLE
#38 fix a bug in "toggleExclude"

### DIFF
--- a/server/src/eventHandlers/excludedFromEstimations.js
+++ b/server/src/eventHandlers/excludedFromEstimations.js
@@ -5,6 +5,7 @@ const excludedFromEstimationsEventHandler = (room, eventPayload, userId) => {
   const modifiedUsers = {
     ...room.users,
     [userId]: {
+      ...room.users[userId],
       excluded: true
     }
   };

--- a/server/src/eventHandlers/includedInEstimations.js
+++ b/server/src/eventHandlers/includedInEstimations.js
@@ -5,6 +5,7 @@ const includedInEstimationsEventHandler = (room, eventPayload, userId) => {
   const modifiedUsers = {
     ...room.users,
     [userId]: {
+      ...room.users[userId],
       excluded: false
     }
   };


### PR DESCRIPTION
during toggling of exclude flag, the id property of the user was lost. this led to "ghost" users in the room, that could no longer be kicked