### PR TITLE
#169 introduce "ErrorBoundary" component in frontend that catches...

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -13,6 +13,7 @@ import initialState from './state/initialState';
 import configureStore from './state/configureStore';
 import {WithL10n} from './services/l10n';
 
+import ErrorBoundary from './components/common/ErrorBoundary';
 import Main from './components/Main';
 import Global from './_styled';
 
@@ -25,11 +26,13 @@ if (appConfig.env === 'dev') {
 
 const store = configureStore(initialState());
 render(
-  <Provider store={store}>
-    <WithL10n>
-      <Global />
-      <Main />
-    </WithL10n>
-  </Provider>,
+  <ErrorBoundary>
+    <Provider store={store}>
+      <WithL10n>
+        <Global />
+        <Main />
+      </WithL10n>
+    </Provider>
+  </ErrorBoundary>,
   document.getElementById('app-root')
 );

--- a/client/app/components/Landing/ErrorPage.js
+++ b/client/app/components/Landing/ErrorPage.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {StyledEyecatcher, StyledInfoText, StyledLanding, StyledLandingInner} from './_styled';
+import Global from '../../_styled';
+
+const ErrorPage = () => {
+  return (
+    <StyledLanding>
+      <Global />
+      <StyledLandingInner>
+        <StyledEyecatcher>
+          <StyledInfoText>
+            <i className="icon-attention-circled"></i>
+            <p>
+              We are sorry, there seems to be a problem...
+              <br />
+              Please try again. Or <a href="mailto:xeronimus@gmail.com">get in touch</a>, if the
+              error persists.
+            </p>
+          </StyledInfoText>
+        </StyledEyecatcher>
+      </StyledLandingInner>
+    </StyledLanding>
+  );
+};
+
+export default ErrorPage;

--- a/client/app/components/common/ErrorBoundary.js
+++ b/client/app/components/common/ErrorBoundary.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ErrorPage from '../Landing/ErrorPage';
+import {reportError} from '../../services/restApi/errorLogService';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {hasRenderingError: false};
+    this.onError = this.onError.bind(this);
+    this.onUnhandledPromiseRejection = this.onUnhandledPromiseRejection.bind(this);
+  }
+
+  onError(event) {
+    reportError('EVENT_HANDLER', event && event.error ? event.error.stack : '');
+  }
+
+  onUnhandledPromiseRejection(event) {
+    reportError('PROMISE_REJECTION', event && event.reason ? event.reason.stack : '');
+  }
+
+  componentDidCatch(error) {
+    // will be invoked for errors/exception during rendering of React components.
+    // see https://reactjs.org/docs/error-boundaries.html
+    reportError('RENDERING', error && error.stack ? error.stack : '');
+  }
+
+  componentDidMount() {
+    window.addEventListener('error', this.onError);
+    window.addEventListener('unhandledrejection', this.onUnhandledPromiseRejection);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('error', this.onError);
+    window.removeEventListener('unhandledrejection', this.onUnhandledPromiseRejection);
+  }
+
+  static getDerivedStateFromError() {
+    return {hasRenderingError: true};
+  }
+
+  render() {
+    if (this.state.hasRenderingError) {
+      return <ErrorPage />;
+    }
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
+};
+
+export default ErrorBoundary;

--- a/client/app/services/restApi/errorLogService.js
+++ b/client/app/services/restApi/errorLogService.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export function reportError(type, error) {
+  return axios.post('/api/errorlog', {type, error}).then((response) => response.data);
+}

--- a/client/app/services/restApi/roomService.js
+++ b/client/app/services/restApi/roomService.js
@@ -31,5 +31,5 @@ export function getRoomExport(roomId, userToken) {
     .get('/api/export/room/' + roomId, {
       headers: getHeaders(userToken)
     })
-    .then((response) => response.data);
+    .then((response) => response.a.data);
 }

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "4.17.1",
     "express-sslify": "1.2.0",
     "fastq": "1.11.0",


### PR DESCRIPTION
various errors and reports them to the backend for logging

- React ErrorBoundary on toplevel in the component tree (this will handle React errors during component rendering)
- also register for unhandled promise rejections
- also register for global errors: window.addEventListener('error',...)
- new REST endpoint in the PoinZ backend that will put "type" and "error" to log