### PR TITLE
#206 Align the "New Round" button on the right side.

### DIFF
--- a/client/app/components/EstimationArea/EstimationArea.js
+++ b/client/app/components/EstimationArea/EstimationArea.js
@@ -65,7 +65,7 @@ const EstimationArea = ({
       </StyledSelectedStory>
 
       {!revealed && (
-        <EstimationAreaButtons>
+        <EstimationAreaButtons alignment="space-between">
           <button
             type="button"
             className="pure-button pure-button-primary"
@@ -79,7 +79,7 @@ const EstimationArea = ({
 
       {revealed && (
         <React.Fragment>
-          <EstimationAreaButtons>
+          <EstimationAreaButtons alignment="flex-end">
             <button
               type="button"
               className="pure-button pure-button-primary"

--- a/client/app/components/EstimationArea/_styled.js
+++ b/client/app/components/EstimationArea/_styled.js
@@ -14,7 +14,15 @@ export const StyledEstimation = styled.div`
 export const EstimationAreaButtons = styled.div`
   margin-top: 16px;
   display: flex;
-  justify-content: space-between;
+  justify-content: ${({alignment}) => alignment};
+
+  > button {
+    margin-right: 4px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 `;
 
 const FlashAnimation = keyframes`


### PR DESCRIPTION
- prevents "double clicking" "reveal" and "new round" and accidentally starting a new round
- "New Round" and "Next Story" belong together semantically