### PR TITLE
#201 Use github actions instead of travis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: npm i
+
+      - name: dependency check
+        run: npm run dependencyCheck
+
+      - name: run tests
+        run: npm test
+
+      - name: run build
+        run: npm run build
+
+      - name: create docker tag
+        run: |
+          docker -v;
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+          docker image push --all-tags "${DOCKER_USERNAME}/poinz" || docker image push "${DOCKER_USERNAME}/poinz";

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,23 @@
+name: pull request
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: npm i
+
+      - name: dependency check
+        run: npm run dependencyCheck
+
+      - name: run tests
+        run: npm test
+
+      - name: run build
+        run: npm run build


### PR DESCRIPTION
Hi

Thanks for the nice application. We use it at work to estimate stories! I like it a lot and wanted to give something back. So I had a quick look at the github actions. It's pretty easy to do. This is suggestion - let me know what you want...

- There are two workflows. The one running on merges on the master branch has the docker tagging in there. This part I didn't test as I haven't set the environment variables.
- The pull request action runs on a new pull request and just builds, but doesn't tag any docker image.

Here you can see how the run looked like: https://github.com/frnkst/poinz/pull/2

Happy to discuss changes. Let me know.

Thanks again!